### PR TITLE
Fix support for mobile devices

### DIFF
--- a/free_haaretz.js
+++ b/free_haaretz.js
@@ -22,6 +22,8 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   function (details) {
     for (var i = 0; i < details.requestHeaders.length; ++i) {
       if (details.requestHeaders[i].name.toLowerCase() === 'user-agent') {
+        if (typeof window.orientation !== 'undefined')
+          details.requestHeaders[i].value = 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
         details.requestHeaders[i].value = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)';
         break;
       }


### PR DESCRIPTION
Using googlebot user agent on mobile is forcing haaretz's desktop site. It doesn't if we use the Googlebot (Smartphone) user agent (https://support.google.com/webmasters/answer/1061943?hl=en).
I've changed the user string under a custom user agent extension in firefox mobile, and it's working, but I didn't manage to test this pull request as I'm struggling with installing the built .xpi file.
Please test it before making any changes.