### PR TITLE
Hide a new overlaying banner

### DIFF
--- a/free_haaretz.css
+++ b/free_haaretz.css
@@ -4,3 +4,6 @@ section#header-reading-list {
 section#header-user-menu {
 	display: none;
 }
+div#botspopup_wrapper {
+	display: none;
+}


### PR DESCRIPTION
Visiting an article like this:
https://www.haaretz.co.il/news/politics/.premium-1.6411447
Prompted a new banner. I added a simple CSS rule to hide it.